### PR TITLE
Moved to using opencv for grayscaling meaning file size is now -20%

### DIFF
--- a/Charcoal/Charcoal/Epub.cpp
+++ b/Charcoal/Charcoal/Epub.cpp
@@ -1,4 +1,4 @@
-#define STB_IMAGE_IMPLEMENTATION
+    #define STB_IMAGE_IMPLEMENTATION
 #define STB_IMAGE_WRITE_IMPLEMENTATION
 //only do this once
 
@@ -11,6 +11,8 @@
 #include "stb_image_write.h"
 #include "filesystem"
 #include <vector>
+#include <opencv2/imgcodecs.hpp>
+#include <opencv2/imgproc/imgproc.hpp>
 #define _CRT_SECURE_NO_WARNINGS
 #pragma once
 book Epub::add(PWSTR path)
@@ -126,9 +128,9 @@ void Epub::grayscaleEpub(PWSTR path) {
             // Read the image file from the epub archive
             int width, height, channels;
             unsigned char* image = stbi_load_from_memory((unsigned char*)entry.readAsBinary(), entry.getSize(), &width, &height, &channels, 0);
-
+            
             // Grayscale the image
-            grayscaleImage(image, width, height);
+            //grayscaleImage(image, width, height);
             
             std::string base_filename = name.substr(name.find_last_of("/\\") + 1);
             if(fileExt == "jpeg" || fileExt == "jpg")
@@ -136,6 +138,9 @@ void Epub::grayscaleEpub(PWSTR path) {
             else if(fileExt == "png")
                 stbi_write_png((temp + base_filename).c_str(), width, height, channels, image, (width * channels));
             // Write the modified image back to the epub archive
+            cv::Mat read_image = cv::imread((temp + base_filename));
+            cv::cvtColor(read_image, read_image, cv::COLOR_BGR2GRAY);
+            cv::imwrite((temp + base_filename), read_image);
             zipArchive.deleteEntry(name);
             zipArchive.addFile(name, (temp + base_filename).c_str());
             file_clean.push_back(temp + base_filename);

--- a/Charcoal/Charcoal/Epub.cpp
+++ b/Charcoal/Charcoal/Epub.cpp
@@ -153,18 +153,3 @@ void Epub::grayscaleEpub(PWSTR path) {
         std::filesystem::remove(file_name);
     }
 }
-
-void Epub::grayscaleImage(unsigned char* imageData, int width, int height) {
-    // Convert RGB image to grayscale
-    for (int i = 0; i < width * height; ++i) {
-        unsigned char gray = static_cast<unsigned char>(
-            0.21f * imageData[3 * i] +
-            0.72f * imageData[3 * i + 1] +
-            0.07f * imageData[3 * i + 2]
-            );
-
-        imageData[3 * i] = gray;
-        imageData[3 * i + 1] = gray;
-        imageData[3 * i + 2] = gray;
-    }
-}


### PR DESCRIPTION
Using the inefficient STBI implementation meant file size increased, defeating the point of the grayscale. 